### PR TITLE
Fix/windows cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "infracost",
 	"displayName": "Infracost",
 	"description": "Cloud cost estimates for Terraform in your editor",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"publisher": "Infracost",
 	"license": "Apache-2.0",
 	"icon": "infracost-logo.png",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -351,7 +351,12 @@ class Workspace {
 
   async run(path: string, init: boolean = false): Promise<infracostJSON.RootObject | undefined> {
     try {
-      const cmd = `infracost breakdown --path ${path} --format json --log-level info`
+      let cmd = `INFRACOST_CLI_PLATFORM=vscode infracost breakdown --path ${path} --format json --log-level info`
+
+      if (os.platform() == 'win32') {
+        cmd = 'cmd /C "set INFRACOST_CLI_PLATFORM=vscode && infracost breakdown --path .'
+      }
+
       const { stdout, stderr } = await util.promisify(exec)(cmd);
       const body = <infracostJSON.RootObject>JSON.parse(stdout);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -351,7 +351,7 @@ class Workspace {
 
   async run(path: string, init: boolean = false): Promise<infracostJSON.RootObject | undefined> {
     try {
-      const cmd = `INFRACOST_CLI_PLATFORM=vscode infracost breakdown --path ${path} --format json --log-level info`
+      const cmd = `infracost breakdown --path ${path} --format json --log-level info`
       const { stdout, stderr } = await util.promisify(exec)(cmd);
       const body = <infracostJSON.RootObject>JSON.parse(stdout);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import resourceRows from './templates/resource-rows.hbs';
 import blockOutput from './templates/block-output.hbs';
 import { join } from 'path';
 import { gte } from 'semver';
+import * as os from 'os';
 
 const Handlebars = create();
 
@@ -112,7 +113,6 @@ function registerTemplates(context: vscode.ExtensionContext) {
   registerPartialFromFile('resourceRows', context.asAbsolutePath(join('dist', resourceRows)))
   registerPartialFromFile('tableHeaders', context.asAbsolutePath(join('dist', tableHeader)))
 }
-
 
 async function isExtensionValid(): Promise<boolean> {
   const terraformExtension = vscode.extensions.getExtension('HashiCorp.terraform');
@@ -365,13 +365,19 @@ class Workspace {
         const formatted = new Project(projectPath, body.currency, this.blockTemplate);
         for (const resource of project.breakdown.resources) {
           for (const call of resource.metadata.calls) {
-            formatted.file(call.filename).block(call.blockName).resources.push(resource);
-
-            if (this.filesToProjects[call.filename] === undefined) {
-              this.filesToProjects[call.filename] = {};
+            let filename = call.filename;
+            if (filename.startsWith('c')) {
+              const slash = /\\+/gi;
+              filename = '/'+filename.replace(slash, '/');
             }
 
-            this.filesToProjects[call.filename][projectPath] = true;
+            formatted.file(filename).block(call.blockName).resources.push(resource);
+
+            if (this.filesToProjects[filename] === undefined) {
+              this.filesToProjects[filename] = {};
+            }
+
+            this.filesToProjects[filename][projectPath] = true;
           }
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -354,7 +354,7 @@ class Workspace {
       let cmd = `INFRACOST_CLI_PLATFORM=vscode infracost breakdown --path ${path} --format json --log-level info`
 
       if (os.platform() == 'win32') {
-        cmd = 'cmd /C "set INFRACOST_CLI_PLATFORM=vscode && infracost breakdown --path .'
+        cmd = `cmd /C "set INFRACOST_CLI_PLATFORM=vscode && infracost breakdown --path ${path} --format json --log-level info"`
       }
 
       const { stdout, stderr } = await util.promisify(exec)(cmd);


### PR DESCRIPTION
Builds upon @dwalker-sabiogroup 's work to solve extension issues with windows:

* solves issue with windows shell crashing because of os variable 
* solves issue with infracost metadata paths provided from the CLI having different format from vscode