### PR TITLE
chore: bump version to 0.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "infracost",
 	"displayName": "Infracost",
 	"description": "Cloud cost estimates for Terraform in your editor",
-	"version": "0.1.15",
+	"version": "0.1.16",
 	"publisher": "Infracost",
 	"license": "Apache-2.0",
 	"icon": "infracost-logo.png",


### PR DESCRIPTION
bumps version to release `infracost auth login` changes