### PR TITLE
refactor: make error message less intrusive

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import logger from './log';
 import CLI from './cli';
 
 export const LOGGED_IN = 'loggedIn';
+export const ERROR = 'error';
 
 class Context {
   private data: { [k: string]: unknown } = {};
@@ -11,7 +12,7 @@ class Context {
     this.data = {};
 
     const buf = await cli.exec('configure', 'get', 'api_key');
-    if (buf.stderr.indexOf('No API key') === -1) {
+    if (buf.stderr && buf.stderr.indexOf('No API key') === -1) {
       await this.set(LOGGED_IN, true);
     }
   }

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,4 +1,5 @@
-import { StatusBarItem, window, StatusBarAlignment, ExtensionContext } from 'vscode';
+import {ExtensionContext, StatusBarAlignment, StatusBarItem, window, ThemeColor, MarkdownString} from 'vscode';
+import context, { ERROR } from './context';
 
 class StatusBar {
   private item: StatusBarItem;
@@ -9,11 +10,26 @@ class StatusBar {
 
   setLoading() {
     this.item.text = '$(sync~spin) Infracost';
+    this.item.tooltip = undefined;
     this.item.show();
   }
 
   setReady() {
+    const error = context.get(ERROR)
+    if (error) {
+      this.setError(`${error}`);
+      return;
+    }
+
     this.item.text = '$(cloud) Infracost';
+    this.item.tooltip = undefined;
+    this.item.show();
+  }
+
+  setError(msg: string) {
+    this.item.text = '$(error) Infracost';
+    this.item.backgroundColor = new ThemeColor('statusBarItem.errorBackground');
+    this.item.tooltip = new MarkdownString(msg);
     this.item.show();
   }
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -8,7 +8,7 @@ import Block from './block';
 import infracostStatus from './statusBar';
 import {cleanFilename, isValidTerraformFile} from './utils';
 import webviews from './webview';
-import context, {LOGGED_IN} from './context';
+import context, {ERROR, LOGGED_IN} from './context';
 
 export default class Workspace {
   loading = false;
@@ -195,27 +195,20 @@ export default class Workspace {
         }
       }
 
+      await context.set(ERROR, undefined);
       return body;
     } catch (error) {
-      if (error instanceof Error) {
-        const msg = error.message ?? '';
-        if (msg.toLowerCase().includes('no infracost_api_key environment')) {
-          window.showErrorMessage(
-            'Please run `infracost auth login` in your terminal to get a free API. This is used by the Infracost CLI to retrieve prices from our Cloud Pricing API, e.g. get prices for instance types.'
-          );
-          return undefined;
-        }
-      }
-
       logger.error(`Infracost cmd error trace ${error}`);
 
       if (init) {
-        window.showErrorMessage(
-          `Could not run the infracost cmd in the ${projectPath} directory. This is likely because of a syntax error or invalid project. See the Infracost Debug output tab for more information. Go to View > Output & select "Infracost Debug" from the dropdown. If this problem continues please open an issue here: https://github.com/infracost/vscode-infracost.`
+        await context.set(
+          ERROR,
+          `Could not run the infracost cmd in the \`${projectPath}\` directory. This is likely because of a syntax error or invalid project.\n\nSee the Infracost Debug output tab for more information. Go to **View > Output** & select "Infracost Debug" from the dropdown. If this problem continues please open an [issue here](https://github.com/infracost/vscode-infracost).`
         );
       } else {
-        window.showErrorMessage(
-          `Error fetching cloud costs with Infracost, please run again by saving the file or reopening the workspace. See the Infracost Debug output tab for more information. Go to View > Output & select "Infracost Debug" from the dropdown. If this problem continues please open an issue here: https://github.com/infracost/vscode-infracost.`
+        await context.set(
+          ERROR,
+          `Error fetching cloud costs with Infracost, please run again by saving the file or reopening the workspace.\n\nSee the Infracost Debug output tab for more information. Go to **View > Output** & select "Infracost Debug" from the dropdown. If this problem continues please open an [issue here](https://github.com/infracost/vscode-infracost).`
         );
       }
     }


### PR DESCRIPTION
Moves error message output to the infracost status bar. Meaning users are not spammed with error popups if there is a problem with their configuration.