### PR TITLE
fix: use npx for vsce publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
       - name: Publish Extension
-        run: yarn vsce publish --yarn --packagePath $(find . -iname *.vsix) -p ${{ secrets.MARKETPLACE_PAT }}
+        run: npx vsce publish --yarn --packagePath $(find . -iname *.vsix) -p ${{ secrets.MARKETPLACE_PAT }}
       - name: Create GitHub release
         id: create_release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
resolves an issue in the pipeline which fails when `package.json` is not available after matrix build