### PR TITLE
fix: use vsce target to specify different manifests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           npm_config_arch: ${{ matrix.npm_config_arch }}
       - name: Package extension
-        run: yarn vscode:package
+        run: yarn vscode:package -- --target=${{ matrix.vsce_target }}
         env:
           INFRACOST_BIN_TARGET: ${{ matrix.bin_target }}
       - name: Upload vsix as artifact
@@ -71,7 +71,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          files: ./${{ env.PACKAGE_NAME }}.vsix
+          files: "*.vsix"
           tag_name: ${{ github.ref }}
           name: v${{ env.PACKAGE_VERSION }}
           draft: true


### PR DESCRIPTION
resolves issue where packages for different arch are failing to be pushed as marketplace thinks they are the same version