### PR TITLE
fix: windows arm exe binary incorrect path

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -48,7 +48,9 @@ rm "/tmp/$tar"
 rm -rf "bin"
 mkdir -p "bin"
 
-if echo "$bin_target" | grep "windows"; then
+if echo "$bin_target" | grep "windows-arm"; then
+  mv "/tmp/infracost-arm64.exe" "bin/infracost.exe"
+elif echo "$bin_target" | grep "windows"; then
   mv "/tmp/infracost.exe" "bin/infracost.exe"
 else
   mv "/tmp/infracost-$bin_target" "bin/infracost"


### PR DESCRIPTION
fixes issues with `infracost-arm` exe bin with incorrect path