### PR TITLE
fix: only display connect to cloud message if the extension is active

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,23 +43,34 @@
     "views": {
       "infracost-projects": [
         {
+          "id": "infracostActivate",
+          "name": "Activate",
+          "when": "!infracost:active"
+        },
+        {
           "id": "infracostAuth",
           "name": "Authenticate",
-          "when": "!infracost:loggedIn"
+          "when": "infracost:active && !infracost:loggedIn"
         },
         {
           "id": "infracostProjects",
           "name": "Projects overview",
           "icon": "media/infracost.svg",
           "contextualTitle": "Infracost Projects",
-          "when": "infracost:loggedIn"
+          "when": "infracost:active && infracost:loggedIn"
         }
       ]
     },
     "viewsWelcome": [
       {
         "view": "infracostAuth",
-        "contents": "Welcome to Infracost for Visual Studio Code.🚀🚀🚀 \nLet's start by connecting VSCode with your Infracost Cloud account:\n[Connect VSCode to Infracost](command:infracost.login 'Connect with Infracost')"
+        "contents": "Welcome to Infracost for Visual Studio Code.🚀🚀🚀 \nLet's start by connecting VSCode with your Infracost Cloud account:\n[Connect VSCode to Infracost](command:infracost.login 'Connect with Infracost')",
+        "when": "infracost:active && !infracost:loggedIn"
+      },
+      {
+        "view": "infracostActivate",
+        "contents": "Open in a Terraform directory or workspace to activate Infracost for Visual Studio Code.",
+        "when": "!infracost:active"
       }
     ],
     "commands": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "publisher": "Infracost",
   "license": "Apache-2.0",
   "icon": "infracost-logo.png",

--- a/src/context.ts
+++ b/src/context.ts
@@ -4,12 +4,14 @@ import CLI from './cli';
 
 export const LOGGED_IN = 'loggedIn';
 export const ERROR = 'error';
+export const ACTIVE = 'active';
 
 class Context {
   private data: { [k: string]: unknown } = {};
 
   async init(cli: CLI) {
     this.data = {};
+    await this.set(ACTIVE, true);
 
     const buf = await cli.exec('configure', 'get', 'api_key');
     if (buf.stderr && buf.stderr.indexOf('No API key') === -1) {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,4 +1,11 @@
-import {ExtensionContext, StatusBarAlignment, StatusBarItem, window, ThemeColor, MarkdownString} from 'vscode';
+import {
+  ExtensionContext,
+  StatusBarAlignment,
+  StatusBarItem,
+  window,
+  ThemeColor,
+  MarkdownString,
+} from 'vscode';
 import context, { ERROR } from './context';
 
 class StatusBar {
@@ -15,7 +22,7 @@ class StatusBar {
   }
 
   setReady() {
-    const error = context.get(ERROR)
+    const error = context.get(ERROR);
     if (error) {
       this.setError(`${error}`);
       return;

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,14 +1,14 @@
 import * as path from 'path';
-import {TemplateDelegate} from 'handlebars';
-import {EventEmitter, TextDocument, TreeItem, window} from 'vscode';
-import CLI, {infracostJSON} from './cli';
+import { TemplateDelegate } from 'handlebars';
+import { EventEmitter, TextDocument, TreeItem, window } from 'vscode';
+import CLI, { infracostJSON } from './cli';
 import logger from './log';
 import Project from './project';
 import Block from './block';
 import infracostStatus from './statusBar';
-import {cleanFilename, isValidTerraformFile} from './utils';
+import { cleanFilename, isValidTerraformFile } from './utils';
 import webviews from './webview';
-import context, {ERROR, LOGGED_IN} from './context';
+import context, { ERROR, LOGGED_IN } from './context';
 
 export default class Workspace {
   loading = false;
@@ -26,8 +26,7 @@ export default class Workspace {
     private cli: CLI,
     private blockTemplate: TemplateDelegate,
     private treeRenderEventEmitter: EventEmitter<TreeItem | undefined | void>
-  ) {
-  }
+  ) {}
 
   async login() {
     logger.debug('executing infracost login');


### PR DESCRIPTION
fixes: https://github.com/infracost/vscode-infracost/issues/86

Resolves issue, where the connect to cloud page, was showing when the extension was not active (not in a Terraform workspace). Which meant the connect button was not functioning.