### PR TITLE
fix: switch spawnExec to spawn to avoid max buffer issues

### DIFF
--- a/.github/workflows/pr-assets.yml
+++ b/.github/workflows/pr-assets.yml
@@ -1,0 +1,54 @@
+name: Build PR assets
+
+on:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build assets
+    strategy:
+      matrix:
+        include:
+          - vsce_target: win32-x64
+            bin_target: windows-amd64
+            npm_config_arch: x64
+          - vsce_target: win32-arm64
+            bin_target: windows-arm64
+            npm_config_arch: arm
+          - vsce_target: linux-x64
+            bin_target: linux-amd64
+            npm_config_arch: x64
+          - vsce_target: linux-arm64
+            bin_target: linux-arm64
+            npm_config_arch: arm64
+          - vsce_target: darwin-x64
+            bin_target: darwin-amd64
+            npm_config_arch: x64
+          - vsce_target: darwin-arm64
+            bin_target: darwin-arm64
+            npm_config_arch: arm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.13.1"
+      - name: Install
+        run: yarn
+        env:
+          npm_config_arch: ${{ matrix.npm_config_arch }}
+      - name: Package extension
+        run: yarn vscode:package -- --target=${{ matrix.vsce_target }}
+        env:
+          INFRACOST_BIN_TARGET: ${{ matrix.bin_target }}
+      - name: Upload vsix as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.vsce_target }}
+          path: "*.vsix"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "publisher": "Infracost",
   "license": "Apache-2.0",
   "icon": "infracost-logo.png",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -89,7 +89,7 @@ export namespace infracostJSON {
   }
 }
 
-type CLIoutput = {
+type CLIOutput = {
   stderr: string;
   stdout: string;
 };
@@ -97,7 +97,7 @@ type CLIoutput = {
 export default class CLI {
   constructor(private binaryPath: string) {}
 
-  async exec(...args: string[]): Promise<CLIoutput> {
+  async exec(...args: string[]): Promise<CLIOutput> {
     const cmd = spawn(this.binaryPath, args, {
       env: {
         ...process.env,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { spawnSync, SpawnSyncReturns } from 'child_process';
+import { spawn } from 'child_process';
 
 export namespace infracostJSON {
   export interface Metadata {
@@ -89,17 +89,42 @@ export namespace infracostJSON {
   }
 }
 
+type CLIoutput = {
+  stderr: string;
+  stdout: string;
+};
+
 export default class CLI {
   constructor(private binaryPath: string) {}
 
-  async exec(...args: string[]): Promise<SpawnSyncReturns<Buffer>> {
-    return spawnSync(this.binaryPath, args, {
+  async exec(...args: string[]): Promise<CLIoutput> {
+    const cmd = spawn(this.binaryPath, args, {
       env: {
         ...process.env,
         INFRACOST_CLI_PLATFORM: 'vscode',
         INFRACOST_NO_COLOR: 'true',
         INFRACOST_SKIP_UPDATE_CHECK: 'true',
       },
+    });
+
+    return new Promise((resolve) => {
+      const stdOut: Uint8Array[] = [];
+      const stdErr: Uint8Array[] = [];
+
+      cmd.stdout.on('data', (data) => {
+        stdOut.push(data);
+      });
+
+      cmd.stderr.on('data', (data) => {
+        stdErr.push(data);
+      });
+
+      cmd.on('close', () => {
+        resolve({
+          stdout: Buffer.concat(stdOut).toString(),
+          stderr: Buffer.concat(stdErr).toString(),
+        });
+      });
     });
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -13,8 +13,8 @@ class Context {
     this.data = {};
     await this.set(ACTIVE, true);
 
-    const buf = await cli.exec('configure', 'get', 'api_key');
-    if (buf.stderr && buf.stderr.indexOf('No API key') === -1) {
+    const out = await cli.exec('configure', 'get', 'api_key');
+    if (out.stderr.indexOf('No API key') === -1) {
       await this.set(LOGGED_IN, true);
     }
   }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -31,15 +31,16 @@ export default class Workspace {
   async login() {
     logger.debug('executing infracost login');
 
-    const buf = await this.cli.exec('auth', 'login');
-    if (buf.stdout.indexOf('Your account has been authenticated') !== -1) {
+    const out = await this.cli.exec('auth', 'login');
+    if (out.stdout.indexOf('Your account has been authenticated') !== -1) {
+      window.showInformationMessage('VS Code is now connected to Infracost');
       logger.debug('successful login response received');
       await context.set(LOGGED_IN, true);
       await this.init();
       return;
     }
 
-    logger.debug(`failed login response was ${buf.stdout}`);
+    logger.debug(`failed login response was ${out.stdout}`);
     await context.set(LOGGED_IN, false);
   }
 
@@ -149,7 +150,7 @@ export default class Workspace {
     try {
       logger.debug(`running Infracost breakdown`);
 
-      const buf = await this.cli.exec(
+      const out = await this.cli.exec(
         'breakdown',
         '--path',
         projectPath,
@@ -159,7 +160,7 @@ export default class Workspace {
         'info'
       );
 
-      const body = <infracostJSON.RootObject>JSON.parse(buf.stdout.toString());
+      const body = <infracostJSON.RootObject>JSON.parse(out.stdout);
 
       for (const project of body.projects) {
         logger.debug(`found project ${project.name}`);


### PR DESCRIPTION
fixes: https://github.com/infracost/vscode-infracost/issues/36

* SpawnExec also seems to have the underlying max buffer issue that execFile had. Switches internals to use `spawn` with callback method to build a buffer which is of unlimited size.
* adds a build asset pipeline to build VSIX assets on the PR