### PR TITLE
fix: remove semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,9 +140,7 @@
     "webpack-cli": "^5.0.2"
   },
   "dependencies": {
-    "@types/semver": "^7.3.12",
     "handlebars": "^4.7.7",
-    "js-yaml": "^4.1.0",
-    "semver": "^7.5.2"
+    "js-yaml": "^4.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2753,7 +2753,7 @@ semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.2:
+semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
   integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==


### PR DESCRIPTION
removes semver as dependency, this is no longer needed since we bundle the CLI.