### PR TITLE
fix: nan monthly cost

### DIFF
--- a/src/block.ts
+++ b/src/block.ts
@@ -31,7 +31,7 @@ export default class Block {
     let cost = 0;
 
     for (const r of this.resources) {
-      if (r.monthlyCost === null) {
+      if (r.monthlyCost == null) {
         r.monthlyCost = 0;
       }
 


### PR DESCRIPTION
fixes #200

Resolves issue where if monthlyCost was `undefined` we were mistakenly adding it to the cost total.