### PR TITLE
fix: show price alongside the resources

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "publisher": "Infracost",
   "license": "Apache-2.0",
   "icon": "infracost-logo.png",

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -302,7 +302,7 @@ export default class Workspace {
       const formatted = new Project(name, projectPath, this.currency, this.blockTemplate);
       for (const resource of project.breakdown.resources) {
         for (const call of resource.metadata.calls) {
-          const filename = cleanFilename(call.filename);
+          const filename = path.resolve(cleanFilename(call.filename));
           logger.debug(`adding file: ${filename} to project: ${projectPath}`);
 
           formatted.setBlock(filename, call.blockName, call.startLine).resources.push(resource);


### PR DESCRIPTION
Update the converter of files to projects so that it uses the absolute
path in the files to projects map. This is required when the document
URI is used to get the latest changes and add the decorations to the
resource.

<img width="533" alt="image" src="https://github.com/infracost/vscode-infracost/assets/3049157/58252d75-39f8-439d-8d5a-88de5abc0d21">


