### PR TITLE
fix: cross platform filenames

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "publisher": "Infracost",
   "license": "Apache-2.0",
   "icon": "infracost-logo.png",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -107,7 +107,7 @@ export default class CLI {
         INFRACOST_CLI_PLATFORM: 'vscode',
         INFRACOST_NO_COLOR: 'true',
         INFRACOST_SKIP_UPDATE_CHECK: 'true',
-        INFRACOST_GRAPH_EVALUATOR: 'true'
+        INFRACOST_GRAPH_EVALUATOR: 'true',
       },
     });
 

--- a/src/lens.ts
+++ b/src/lens.ts
@@ -1,11 +1,5 @@
-import {
-  CodeLens,
-  CodeLensProvider,
-  Event,
-  TextDocument,
-} from 'vscode';
+import { CodeLens, CodeLensProvider, Event, TextDocument } from 'vscode';
 import Workspace from './workspace';
-import { cleanFilename } from './utils';
 import logger from './log';
 import { InfracostCommand } from './command';
 import context from './context';
@@ -26,12 +20,11 @@ export default class InfracostLensProvider implements CodeLensProvider {
     }
 
     const lenses: CodeLens[] = [];
-    const filename = cleanFilename(document.uri.path);
+    const filename = document.uri.fsPath;
     logger.debug(`providing codelens for file ${filename}`);
-
     const blocks = this.workspace.project(filename);
     for (const block of Object.values(blocks)) {
-      if (block.filename !== filename) {
+      if (block.filename.toLowerCase() !== filename.toLowerCase()) {
         continue;
       }
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -115,7 +115,14 @@ export default class Workspace {
 
     logger.debug(`detected file change for path ${filename}`);
 
-    const projects = this.filesToProjects[filename];
+   const key = filename.split(path.sep).join('/');
+    const projects =
+      this.filesToProjects[
+        Object.keys(this.filesToProjects).find(
+          (k: string) => k.toLowerCase() === key.toLowerCase()
+        ) || key
+      ];
+
     if (projects === undefined) {
       logger.debug(
         `no valid projects found for path ${filename} attempting to locate project for file`
@@ -155,10 +162,16 @@ export default class Workspace {
 
   // TODO: determine or allow users to switch the project they are using.
   project(filename: string): { [key: string]: Block } {
-    const projects = this.filesToProjects[filename];
+    const key = filename.split(path.sep).join('/');
+    const projectKey =
+      this.filesToProjects[
+        Object.keys(this.filesToProjects).find(
+          (k: string) => k.toLowerCase() === key.toLowerCase()
+        ) || key
+      ];
 
-    if (projects && Object.keys(projects).length > 0) {
-      const project = Object.keys(projects)[0];
+    if (projectKey && Object.keys(projectKey).length > 0) {
+      const project = Object.keys(projectKey)[0];
       return this.projects[project].blocks;
     }
 
@@ -302,7 +315,7 @@ export default class Workspace {
       const formatted = new Project(name, projectPath, this.currency, this.blockTemplate);
       for (const resource of project.breakdown.resources) {
         for (const call of resource.metadata.calls) {
-          const filename = path.resolve(cleanFilename(call.filename));
+          const filename = cleanFilename(path.resolve(call.filename));
           logger.debug(`adding file: ${filename} to project: ${projectPath}`);
 
           formatted.setBlock(filename, call.blockName, call.startLine).resources.push(resource);
@@ -327,10 +340,11 @@ export default class Workspace {
   }
 
   private addProjectToFile(filename: string, projectPath: string) {
-    if (this.filesToProjects[filename] === undefined) {
-      this.filesToProjects[filename] = {};
+    const key = filename.split(path.sep).join('/');
+    if (this.filesToProjects[key] === undefined) {
+      this.filesToProjects[key] = {};
     }
 
-    this.filesToProjects[filename][projectPath] = true;
+    this.filesToProjects[key][projectPath] = true;
   }
 }


### PR DESCRIPTION
Support filenames across platforms without fighting with the backslash

*Mac*
<img width="1484" alt="image" src="https://github.com/infracost/vscode-infracost/assets/3049157/0fe36a71-9ebb-48ec-bbea-ad480563f8df">


*Linux (Ubuntu)*
![image](https://github.com/infracost/vscode-infracost/assets/3049157/7cee2a78-e887-4f56-a303-ed13c05815f8)

*Windows*
![image](https://github.com/infracost/vscode-infracost/assets/3049157/72439a18-d0d6-4a57-8f14-73cacd17baba)
