### PR TITLE
fix: config file not resolving

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.2.29",
+  "version": "0.2.30",
   "publisher": "Infracost",
   "license": "Apache-2.0",
   "icon": "infracost-logo.png",

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,4 +6,5 @@ export type ConfigFile = {
 export type ConfigProject = {
   path: string;
   name: string;
+  skip_autodetect: boolean;
 };

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -101,9 +101,12 @@ export default class InfracostProjectProvider implements TreeDataProvider<Infrac
           .sort((a: File, b: File): number => b.rawCost() - a.rawCost())
           .reduce((arr: InfracostTreeItem[], f: File): InfracostTreeItem[] => {
             const name = path.basename(f.name);
-            const filePath = path.relative(element.key, f.name);
+            const filePath =
+              process.platform === 'win32'
+                ? path.resolve(element.key, name)
+                : path.resolve(element.key, f.name);
 
-            if (filePath === name) {
+            if (filePath === f.name) {
               const item = new InfracostTreeItem(
                 `${element.key}|${f.name}`,
                 name,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import { commands, SymbolInformation, TextDocument } from 'vscode';
+import { Buffer } from 'buffer';
+import * as fs from 'fs';
 import logger from './log';
 
 export const CONFIG_FILE_NAME = 'infracost.yml';
@@ -36,4 +38,17 @@ export async function isValidTerraformFile(file: TextDocument): Promise<boolean>
   }
 
   return true;
+}
+
+export async function getFileEncoding(filepath: string): Promise<string> {
+  const d = Buffer.alloc(5, 0);
+  const fd = fs.openSync(filepath, 'r');
+  fs.readSync(fd, d, 0, 5, 0);
+  fs.closeSync(fd);
+
+  if (d[0] === 0xef && d[1] === 0xbb && d[2] === 0xbf) return 'utf8';
+  if (d[0] === 0xfe && d[1] === 0xff) return 'utf16be';
+  if (d[0] === 0xff && d[1] === 0xfe) return 'utf16le';
+
+  return 'utf8';
 }


### PR DESCRIPTION
Resolves an issue when the `--config-file` flag is used and the relative path isn't correctly resolved. This affects both the lens and the tree structure.

The previous fix for relative paths only addressed when `--path` was used, no `--config-file`

Tested in Windows, MacOS and Linux

Bump version
