### PR TITLE
Windows drive fix

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,10 +8,10 @@ export const CONFIG_TEMPLATE_NAME = 'infracost.yml.tmpl';
 export const USAGE_FILE_NAME = 'infracost-usage.yml';
 
 export function cleanFilename(filename: string): string {
-  const replaceC = /^\/C/g;
-  let cleaned = filename.replace(replaceC, '/c');
+  const replaceDrive = /^\/[A-Z]:/g;
+  let cleaned = filename.replace(replaceDrive, (match) => match.toLowerCase());
 
-  if (cleaned.startsWith('c')) {
+  if (cleaned.match(/^[a-z]:/)) {
     const slash = /\\+/gi;
     cleaned = `/${cleaned.replace(slash, '/')}`;
   }


### PR DESCRIPTION
This is a minor fix, could be critical in certain scenarios.

BUG: 
I had created a project in D drvie of my PC with just one file (main.tf) with a minimalistic code as shown below.
When I launch VS code for the first time, I see the correct costs being displayed. However when I make changes to main.tf and save the file, I do not see the changes in the cost. 

STEPS TO REPRODUCE:

1. Create a folder in D drive. (I have used `D:\Github_Projs\Dummy\01-hello-world-Terraform`)
2. Create a main.tf file with the following contents:
```
        # Configure the AWS provider
        provider "aws" {
          region = "eu-west-1"
        } 
        # Create an EC2 instance
        resource "aws_instance" "example" {
          ami           = "ami-785db401"
          instance_type = "t3.micro"
        }
```
3. Open VS code (Make sure Terraform extension and Infracost are installed)
4. Open `main.tf` and modify the `instance_type` ( change it to t2.micro for example) 
5. Observe that the shown cost doesn't change. 

VIDEO OF THE BUG:

https://github.com/user-attachments/assets/6e12134e-02ec-4c55-a758-05de153a025d


DEBUG LOGS:
[debug_logs.txt](https://github.com/user-attachments/files/16190079/debug_logs.txt)

CAUSE OF THE PROBLEM:
The cause of the problem seems to be in `workspace.ts` in the method  `async fileChange()` when comparing `projectDir `and `dir`(look at the valies on the left hand side)
![projectDirString](https://github.com/user-attachments/assets/ca09943e-c991-4083-8c4d-7b21378eb3f0)

This is happening because the `cleanFilename()` method in `utils.ts` isn't cleaning the path with all the drives( just the C drive)
![cleanFileMaster](https://github.com/user-attachments/assets/edbd31c7-2ad3-47f4-8beb-8622618f685b)

In short, if I have a terraform project placed in any drive apart from the C drive, the extension might not work as expectd. (Possible work-around would be to make changes to the file and re-open VS code)

FIX: 
I have fixed this issue in this PR, ensuring that all windows drive paths are replaced correctly by modifying the `cleanFilename()`

VIDEO OF THE FIX:

https://github.com/user-attachments/assets/b50a7623-1026-41cd-bd04-f5741d92693d



Here is a ZIP file of the dummy project that I am using in case this is needed for reproducing the issue:
[01-hello-world-Terraform.zip](https://github.com/user-attachments/files/16190224/01-hello-world-Terraform.zip)


