### PR TITLE
chore: bump version to trigger new release

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "publisher": "Infracost",
   "license": "Apache-2.0",
   "icon": "infracost-logo.png",
@@ -142,4 +142,3 @@
     "js-yaml": "^4.1.0"
   }
 }
-


### PR DESCRIPTION
Pick  up the latests infracost release (v0.10.39)
