### PR TITLE
feat: Add support for client restart

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,12 +15,20 @@ import { StatusInfo } from './resourceHtml';
 let client: LanguageClient | undefined;
 let resourceViewProvider: ResourceViewProvider;
 let extensionPath: string;
+let pendingLogin: { uri: string; userCode: string } | undefined;
+
+function resolveServerPath(extensionPath: string): string {
+  const binaryName = os.platform() === 'win32' ? 'infracost-ls.exe' : 'infracost-ls';
+  const bundledPath = path.join(extensionPath, 'bin', binaryName);
+  if (fs.existsSync(bundledPath)) {
+    return bundledPath;
+  }
+  return binaryName;
+}
 
 function createClient(): LanguageClient {
   const config = vscode.workspace.getConfiguration('infracost');
-  const binaryPath = os.platform() === 'win32' ? 'infracost-ls.exe' : 'infracost-ls';
-  const defaultPath = path.join(extensionPath, 'bin', binaryPath);
-  const serverPath = config.get<string>('serverPath') || defaultPath;
+  const serverPath = config.get<string>('serverPath') || resolveServerPath(extensionPath);
 
   const serverEnv: Record<string, string> = { ...process.env } as Record<string, string>;
   const debug = config.get<boolean>('debug', false);
@@ -65,14 +73,9 @@ export function activate(context: vscode.ExtensionContext) {
   client
     .start()
     .then(async () => {
-      await client?.setTrace(Trace.fromString(trace));
-      client?.onNotification('infracost/updateAvailable', handleUpdateAvailable);
-      client?.onNotification('infracost/scanComplete', handleScanComplete);
-      client?.onNotification('infracost/loginComplete', () => {
-        pendingLogin = undefined;
-        resourceViewProvider.update({ scanning: true });
-      });
-      checkAuthStatus();
+      if (client) {
+        await setupClient(client);
+      }
     })
     .catch((error) => {
       client = undefined;
@@ -187,8 +190,6 @@ export function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  let pendingLogin: { uri: string; userCode: string } | undefined;
-
   context.subscriptions.push(
     vscode.commands.registerCommand('infracost.login', async () => {
       if (!client) {
@@ -236,8 +237,7 @@ export function activate(context: vscode.ExtensionContext) {
           : { error: 'Language server not running' };
 
         const config = vscode.workspace.getConfiguration('infracost');
-        const lspPath =
-          config.get<string>('serverPath') || path.join(extensionPath, 'bin', 'infracost-ls');
+        const lspPath = config.get<string>('serverPath') || resolveServerPath(extensionPath);
 
         const bundle = {
           timestamp: new Date().toISOString(),
@@ -264,6 +264,23 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
+    vscode.commands.registerCommand('infracost.restartClient', async () => {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: 'Restarting Infracost client...',
+        },
+        async () => {
+          if (client) {
+            await client.restart();
+            await setupClient(client);
+          }
+        }
+      );
+    })
+  );
+
+  context.subscriptions.push(
     vscode.commands.registerCommand('infracost.restartLsp', async () => {
       await vscode.window.withProgress(
         {
@@ -282,6 +299,7 @@ export function activate(context: vscode.ExtensionContext) {
           client = createClient();
           resourceViewProvider.setClient(client);
           await client.start();
+          await setupClient(client);
         }
       );
     })
@@ -299,6 +317,18 @@ function isSupportedFile(fsPath: string): boolean {
     return cfnPatterns.some((p) => base.includes(p));
   }
   return false;
+}
+
+async function setupClient(c: LanguageClient): Promise<void> {
+  const trace = vscode.workspace.getConfiguration('infracost').get<string>('trace.server', 'off');
+  await c.setTrace(Trace.fromString(trace));
+  c.onNotification('infracost/updateAvailable', handleUpdateAvailable);
+  c.onNotification('infracost/scanComplete', handleScanComplete);
+  c.onNotification('infracost/loginComplete', () => {
+    pendingLogin = undefined;
+    resourceViewProvider.update({ scanning: true });
+  });
+  await checkAuthStatus();
 }
 
 async function checkAuthStatus() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,8 +68,6 @@ export function activate(context: vscode.ExtensionContext) {
   extensionPath = context.extensionPath;
   client = createClient();
 
-  const trace = vscode.workspace.getConfiguration('infracost').get<string>('trace.server', 'off');
-
   client
     .start()
     .then(async () => {

--- a/src/resourceHtml.ts
+++ b/src/resourceHtml.ts
@@ -447,6 +447,7 @@ export function renderTroubleshooting(status: StatusInfo): string {
 <div class="section">
   <strong>Actions</strong>
   <ul class="project-list">
+    <li><a href="#" onclick="document.dispatchEvent(new CustomEvent('infracost',{detail:{command:'restartClient'}}));return false;">Restart client</a></li>
     <li><a href="#" onclick="document.dispatchEvent(new CustomEvent('infracost',{detail:{command:'restartLsp'}}));return false;">Restart language server</a></li>
     <li><a href="#" onclick="document.dispatchEvent(new CustomEvent('infracost',{detail:{command:'viewLogs'}}));return false;">View logs</a></li>
     <li><a href="#" onclick="document.dispatchEvent(new CustomEvent('infracost',{detail:{command:'generateBundle'}}));return false;">Generate support bundle</a></li>

--- a/src/resourceView.ts
+++ b/src/resourceView.ts
@@ -52,6 +52,9 @@ export class ResourceViewProvider implements vscode.WebviewViewProvider {
       if (msg.command === 'troubleshoot') {
         this.showTroubleshooting();
       }
+      if (msg.command === 'restartClient') {
+        vscode.commands.executeCommand('infracost.restartClient');
+      }
       if (msg.command === 'restartLsp') {
         vscode.commands.executeCommand('infracost.restartLsp');
       }


### PR DESCRIPTION
This change adds support for restarting the LSP client manually from the
troubleshooting pane. This also tightens up the resolution of the binary
so to look in the extension folder then fall back to the path.
