### PR TITLE
chore: raise vscode engine floor to 1.100

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ In addition to Terraform (`.tf`) files, the extension supports CloudFormation te
 ## Get started
 
 > [!NOTE]
-> **Prerequisites:** Make sure you have VS Code **v1.75.0** or above and an [Infracost account](https://www.infracost.io). See [Requirements](#requirements) for details.
+> **Prerequisites:** Make sure you have VS Code **v1.100.0** or above and an [Infracost account](https://www.infracost.io). See [Requirements](#requirements) for details.
 
 ### 1. Install the extension
 
@@ -95,7 +95,7 @@ Open a workspace containing Terraform files. The extension will start the langua
 
 ## Requirements
 
-- VS Code **v1.75.0** or above
+- VS Code **v1.100.0** or above
 - An [Infracost](https://www.infracost.io) account
 
 ## Configuration

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "vscode-languageserver-protocol": "^3.17.5"
       },
       "devDependencies": {
-        "@types/node": "18.x",
-        "@types/vscode": "^1.75.0",
+        "@types/node": "20.x",
+        "@types/vscode": "^1.100.0",
         "@typescript-eslint/eslint-plugin": "^5.59.9",
         "@typescript-eslint/parser": "^5.59.1",
         "@vscode/vsce": "^3.7.1",
@@ -33,7 +33,7 @@
         "webpack-cli": "^5.0.2"
       },
       "engines": {
-        "vscode": "^1.75.0"
+        "vscode": "^1.100.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -1233,13 +1233,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -8118,9 +8118,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "icon": "infracost-logo.png",
   "engines": {
-    "vscode": "^1.75.0"
+    "vscode": "^1.100.0"
   },
   "categories": [
     "Other",
@@ -133,8 +133,8 @@
     "format:check": "prettier --check 'src/**/*.{js,ts}'"
   },
   "devDependencies": {
-    "@types/node": "18.x",
-    "@types/vscode": "^1.75.0",
+    "@types/node": "20.x",
+    "@types/vscode": "^1.100.0",
     "@typescript-eslint/eslint-plugin": "^5.59.9",
     "@typescript-eslint/parser": "^5.59.1",
     "@vscode/vsce": "^3.7.1",


### PR DESCRIPTION
## Why

VS Code 1.100 was released May 2025 (~12 months ago) — using it as the floor lets us drop ~2 years of pre-Node-20 builds and safely move `@types/node` to `20.x` and `@types/vscode` to `^1.100.0`, since 1.100 ships Node 20 in the extension host.

## Scope

- `engines.vscode` ^1.75.0 → ^1.100.0
- `@types/vscode` ^1.75.0 → ^1.100.0
- `@types/node` 18.x → 20.x
- README prerequisite mentions