### PR TITLE
chore(ci): bump CI Node from 20 to 24

### DIFF
--- a/.github/workflows/pr-assets.yml
+++ b/.github/workflows/pr-assets.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
       - name: Install
         run: npm ci

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
 
       - name: Setup Environment

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
## Why

Node 20 hits EOL April 2026 — moving CI to Node 24 (current LTS) before that. Build-only change: doesn't affect the extension's VS Code engine floor or the runtime Node API surface (those are gated by \`@types/node\`).

Side benefit: unblocks \`webpack-cli@7\` (PR #250), which requires Node ≥22.