### PR TITLE
chore: bump version to 0.4.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "infracost",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "infracost",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.45",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "author": "Infracost",
   "publisher": "Infracost",
   "license": "Apache-2.0",


### PR DESCRIPTION
Version bump for a security-patch release: the only change since v0.4.10 is the dependabot fix (#319), which patched transitive dev dependencies (undici, form-data, tmp, js-yaml, markdown-it, qs). Once merged, tagging v0.4.11 triggers the release workflow, which builds all targets, bundles the latest lsp, and publishes to the VS Code Marketplace and OpenVSX.