### PR TITLE
chore: release v0.4.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "infracost",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "infracost",
-      "version": "0.4.11",
+      "version": "0.4.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.45",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "author": "Infracost",
   "publisher": "Infracost",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Release **v0.4.12** of the VS Code extension.

Bumps `version` to `0.4.12` (in `package.json` + `package-lock.json`). The extension bundles the LSP binary at package time, and this release will pull in **infracost-ls [v0.3.28](https://github.com/infracost/lsp/releases/tag/v0.3.28)** (the current latest LSP release), which fixes [FIX-394](https://linear.app/infracost/issue/FIX-394/infracost-ls-silently-reports-0-resources-when-plugin-cache-has-a-name): the plugin-cache name collision that caused the extension to silently report 0 resources.

## Release steps (after merge)

Once merged to `master`, push the matching tag to trigger the build + publish workflow:

```bash
git tag v0.4.12
git push origin v0.4.12
```

`release.yml` verifies the tag matches `package.json`, builds the `.vsix` for all 6 targets (each bundling the latest LSP release), and publishes to the VS Marketplace and OpenVSX.
