### PR TITLE
feat: add proxy-aware LSP startup and update-check toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,15 @@ Open a workspace containing Terraform files. The extension will start the langua
 
 ## Configuration
 
-| Setting                              | Description                                                                           | Default   |
-| ------------------------------------ | ------------------------------------------------------------------------------------- | --------- |
-| `infracost.serverPath`               | Path to the `lsp` binary. Leave empty to use the bundled binary.                      | (bundled) |
-| `infracost.currency`                 | Currency to use for cost estimates. Options include all currencies supported by the pricing API. | `USD`     |
+| Setting                                | Description                                                                                                    | Default   |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------- | --------- |
+| `infracost.serverPath`                 | Path to the `lsp` binary. Leave empty to use the bundled binary.                                               | (bundled) |
+| `infracost.currency`                   | Currency to use for cost estimates. Options include all currencies supported by the pricing API.               | `USD`     |
 | `infracost.displayRemoteModulesInTree` | Show resources from remote modules in the Explorer tree. Remote module sources cannot be opened from the tree. | `false`   |
-| `infracost.runParamsCacheTTLSeconds` | How long (in seconds) to cache run parameters between API calls. Set to 0 to disable. | `300`     |
+| `infracost.checkForUpdates`            | Check for updates to the bundled Infracost language server.                                                    | `true`    |
+| `infracost.runParamsCacheTTLSeconds`   | How long (in seconds) to cache run parameters between API calls. Set to 0 to disable.                          | `300`     |
+
+The extension also passes VS Code's `http.proxy` setting to the bundled language server when `HTTP_PROXY`/`HTTPS_PROXY` environment variables are not already set.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "infracost",
   "displayName": "Infracost",
   "description": "Cloud cost estimates for Terraform in your editor",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "author": "Infracost",
   "publisher": "Infracost",
   "license": "Apache-2.0",
@@ -89,6 +89,11 @@
           "type": "boolean",
           "default": false,
           "description": "Show resources from remote modules in the Explorer tree. Remote module sources cannot be opened from the tree."
+        },
+        "infracost.checkForUpdates": {
+          "type": "boolean",
+          "default": true,
+          "description": "Check for updates to the bundled Infracost language server."
         },
         "infracost.currency": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,13 +27,70 @@ function resolveServerPath(extensionPath: string): string {
   return binaryName;
 }
 
+function hasEnv(env: Record<string, string>, ...names: string[]): boolean {
+  return names.some((name) => Boolean(env[name]));
+}
+
+function envValue(env: Record<string, string>, ...names: string[]): string | undefined {
+  return names.map((name) => env[name]).find(Boolean);
+}
+
+function getVsCodeProxyEnv(serverEnv: Record<string, string>): Record<string, string> {
+  const httpConfig = vscode.workspace.getConfiguration('http');
+  const proxySupport = httpConfig.get<string>('proxySupport', 'override');
+  if (proxySupport === 'off') {
+    return {};
+  }
+
+  const proxy = httpConfig.get<string>('proxy', '').trim();
+  if (!proxy) {
+    return {};
+  }
+
+  const proxyEnv: Record<string, string> = {};
+  if (!hasEnv(serverEnv, 'HTTPS_PROXY', 'https_proxy')) {
+    proxyEnv.HTTPS_PROXY = envValue(serverEnv, 'HTTP_PROXY', 'http_proxy') || proxy;
+  }
+  if (!hasEnv(serverEnv, 'HTTP_PROXY', 'http_proxy')) {
+    proxyEnv.HTTP_PROXY = proxy;
+  }
+  return proxyEnv;
+}
+
+function getLspProxySettings():
+  { httpProxy?: string; httpsProxy?: string; noProxy?: string } | undefined {
+  const httpConfig = vscode.workspace.getConfiguration('http');
+  const proxySupport = httpConfig.get<string>('proxySupport', 'override');
+  const httpProxy = envValue(process.env as Record<string, string>, 'HTTP_PROXY', 'http_proxy');
+  const httpsProxy = envValue(process.env as Record<string, string>, 'HTTPS_PROXY', 'https_proxy');
+  const noProxy = envValue(process.env as Record<string, string>, 'NO_PROXY', 'no_proxy');
+  const settingsProxy =
+    proxySupport !== 'off' ? httpConfig.get<string>('proxy', '').trim() : undefined;
+
+  const proxy = httpProxy || httpsProxy || settingsProxy;
+  if (!proxy) {
+    return undefined;
+  }
+
+  return {
+    httpProxy: httpProxy || settingsProxy,
+    httpsProxy: httpsProxy || httpProxy || settingsProxy,
+    noProxy,
+  };
+}
+
 function createClient(): LanguageClient {
   const config = vscode.workspace.getConfiguration('infracost');
   const serverPath = config.get<string>('serverPath') || resolveServerPath(extensionPath);
   const currency = config.get<string>('currency', 'USD');
+  const checkForUpdates = config.get<boolean>('checkForUpdates', true);
 
-  const serverEnv: Record<string, string> = { ...process.env } as Record<string, string>;
-  serverEnv.INFRACOST_CLI_CURRENCY = currency;
+  const baseEnv = { ...process.env } as Record<string, string>;
+  const serverEnv: Record<string, string> = {
+    ...baseEnv,
+    ...getVsCodeProxyEnv(baseEnv),
+    INFRACOST_CLI_CURRENCY: currency,
+  };
   const debug = config.get<boolean>('debug', false);
   if (debug) {
     const debugUI = config.get<string>('debugUI', '');
@@ -62,6 +119,8 @@ function createClient(): LanguageClient {
       extensionVersion:
         vscode.extensions.getExtension('Infracost.infracost')?.packageJSON?.version ?? 'unknown',
       currency,
+      checkForUpdates,
+      proxy: getLspProxySettings(),
     },
   };
 
@@ -504,6 +563,13 @@ async function handleUpdateAvailable(params: {
   latestVersion: string;
   currentVersion: string;
 }) {
+  const checkForUpdates = vscode.workspace
+    .getConfiguration('infracost')
+    .get<boolean>('checkForUpdates', true);
+  if (!checkForUpdates) {
+    return;
+  }
+
   if (!params.updateAvailable) {
     return;
   }

--- a/src/resourceHtml.ts
+++ b/src/resourceHtml.ts
@@ -1051,7 +1051,11 @@ ${renderFooterLinks()}
 }
 
 export function renderScanning(opts?: RenderOptions): string {
-  return renderPage(`<div class="state">Scanning...</div>`, opts);
+  return renderPage(
+    `<div class="state">Scanning...</div>
+${renderFooterLinks()}`,
+    opts,
+  );
 }
 
 export function renderLogin(): string {


### PR DESCRIPTION
Pass VS Code proxy settings through to the bundled language server, keep
existing env proxy vars as highest priority, and allow disabling update
checks from extension settings.

Also keep footer links visible while scanning.
